### PR TITLE
Ignore operator spacing

### DIFF
--- a/config/style_guides/coffeescript.json
+++ b/config/style_guides/coffeescript.json
@@ -79,7 +79,7 @@
     },
     "space_operators": {
         "name": "space_operators",
-        "level": "warn"
+        "level": "ignore"
     },
     "duplicate_key": {
         "name": "duplicate_key",


### PR DESCRIPTION
Until we can expect no spaces around default args.  See https://github.com/clutchski/coffeelint/pull/438

Prompted by https://github.com/goodeggs/garbanzo/pull/3123/files#r51074317

@dlau thanks for the pointers

cc @golyshev 
